### PR TITLE
compile CUDA kernels JIT by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,5 @@
 # -- Everything needed just to run setup.py ---------------
 requires = [
     "setuptools>=62",      # the build backend
-    "wheel",
-    "torch",              # provides torch.utils.cpp_extension
-    "ninja",         # speeds up C++/CUDA builds
-    "numpy"          # setup.py imports numpy for version checks
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ exec(open("gsplat/version.py", "r").read())
 
 URL = "https://github.com/nerfstudio-project/gsplat"
 
-BUILD_NO_CUDA = os.getenv("BUILD_NO_CUDA", "0") == "1"
+BUILD_CUDA = os.getenv("BUILD_CUDA", "0") == "1"
 WITH_SYMBOLS = os.getenv("WITH_SYMBOLS", "0") == "1"
 LINE_INFO = os.getenv("LINE_INFO", "0") == "1"
 
@@ -137,8 +137,8 @@ setup(
             "twine",
         ],
     },
-    ext_modules=get_extensions() if not BUILD_NO_CUDA else [],
-    cmdclass={"build_ext": get_ext()} if not BUILD_NO_CUDA else {},
+    ext_modules=get_extensions() if BUILD_CUDA else [],
+    cmdclass={"build_ext": get_ext()} if BUILD_CUDA else {},
     packages=find_packages(),
     # https://github.com/pypa/setuptools/issues/1461#issuecomment-954725244
     include_package_data=True,


### PR DESCRIPTION
This enables one to simply add this repo as a dependency in the pyproject.toml like so:
```
"gsplat@git+https://github.com/carlinds/splatad.git",
```
and when installing the parent package it does not try to compile the CUDA kernels by default, which caused issues. Instead it compile JIT when running the code

More testing needed