### PR TITLE
[ROCm] Add AMD GPU support for SplatAD camera and lidar rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,7 @@ compile_commands.json
 
 data
 results
+# ROCm: torch-hipify mirror (generated at build time, never committed)
+gsplat/hip/
+# ROCm Windows: _winhip.cu shims generated at build time to route .cpp through hipcc
+*_winhip.cu

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ While the code contians all components needed to efficiently render camera and l
 # Installation
 Our code introduce no additional dependencies. We thus refer to the original documentation from gsplat for both [installation](https://github.com/nerfstudio-project/gsplat#installation) and [development setup](https://github.com/nerfstudio-project/gsplat/blob/main/docs/DEV.md).
 
+Both the camera and lidar rendering paths also build and run on AMD GPUs via ROCm. Install a ROCm build of PyTorch, then `pip install` as usual with `BUILD_CUDA=1` and `PYTORCH_ROCM_ARCH` set to your GPU's architecture (for example `gfx90a`, `gfx1100`, or `gfx1201`); the CUDA sources are hipified automatically at build time. The kernels are validated against the project's pure-PyTorch reference on both wave64 (CDNA) and wave32 (RDNA) hardware.
+
 # Usage
 See [`rasterization`](gsplat/rendering.py#L22) and [`lidar_rasterization`]((gsplat/rendering.py#L443)) for entry points to camera and lidar rasterization.
 Additionally, we provide example notebooks under [examples](examples) that demonstrate lidar rendering and rolling shutter compensation.

--- a/gsplat/cuda/csrc/bindings.h
+++ b/gsplat/cuda/csrc/bindings.h
@@ -1,6 +1,21 @@
+#ifdef __HIP__
+// Make HIP's device memcpy overload (amd_device_functions.h) visible before GLM:
+// glm::make_vec/make_mat (type_ptr.inl) call bare memcpy from __host__ __device__
+// accessors, and GLM is included first, so without the HIP runtime in scope the
+// device pass binds the __host__ libc memcpy and clang errors. CUDA's nvcc is
+// lenient and needs no such hint. Use __HIP__ (defined by hipcc, not by the MSVC
+// host compiler on Windows) so MSVC does not try to include hip_runtime.h.
+#include <hip/hip_runtime.h>
+#endif
 #include "third_party/glm/glm/glm.hpp"
 #include "third_party/glm/glm/gtc/type_ptr.hpp"
+#if defined(__HIP__) || defined(__CUDACC__)
+// c10/cuda/CUDAGuard.h pulls in cuda/hip runtime headers that require the GPU
+// compiler (__CUDACC__/__HIP__) to be active. On Windows, the MSVC host compiler
+// processes ext.cpp without these macros, so skip the include there; DEVICE_GUARD
+// (defined below) is only called from .cu/.hip files compiled by hipcc/nvcc.
 #include <c10/cuda/CUDAGuard.h>
+#endif
 #include <torch/extension.h>
 #include <tuple>
 

--- a/gsplat/cuda/csrc/helpers.cuh
+++ b/gsplat/cuda/csrc/helpers.cuh
@@ -1,10 +1,25 @@
 #ifndef GSPLAT_CUDA_HELPERS_H
 #define GSPLAT_CUDA_HELPERS_H
 
+#ifdef __HIP__
+// Make HIP's device memcpy overload (amd_device_functions.h) visible before GLM:
+// glm::make_vec/make_mat (type_ptr.inl) call bare memcpy from __host__ __device__
+// accessors, so the HIP runtime must be in scope first or the device pass binds
+// the __host__ libc memcpy and clang errors. CUDA's nvcc is lenient. Use __HIP__
+// (defined by hipcc) not USE_ROCM (defined for all TUs incl. host-only MSVC .cpp
+// on Windows) so MSVC does not try to include hip_runtime.h via cl.exe.
+#include <hip/hip_runtime.h>
+#endif
 #include "third_party/glm/glm/glm.hpp"
 #include "third_party/glm/glm/gtc/type_ptr.hpp"
 #include <cooperative_groups.h>
+#if !defined(USE_ROCM)
+// HIP's cooperative_groups (ROCm 7.2.x) ships no <cooperative_groups/reduce.h>
+// and no cg::reduce; the butterfly warpReduceSum/Max below replace it. hipify
+// leaves this include verbatim (it maps only <cooperative_groups.h>), so it
+// must be guarded out explicitly.
 #include <cooperative_groups/reduce.h>
+#endif
 
 #include <ATen/cuda/Atomic.cuh>
 
@@ -14,45 +29,120 @@
 
 namespace cg = cooperative_groups;
 
+#if defined(USE_ROCM)
+// HIP's cooperative_groups has no cg::labeled_partition (used by the packed /
+// fused projection backward to coalesce per-gaussian/per-camera gradient atomics
+// so each distinct label does ONE atomicAdd instead of one per lane). Rebuild it
+// from match_any: LabeledGroup holds the 64-bit mask of same-label lanes; its
+// reduction sums only those lanes and only the lowest such lane (thread_rank==0)
+// issues the atomic. Matching the CUDA atomic count matters: v_viewmats/v_R/v_t
+// are summed over many gaussians, and a per-lane atomic fan-out adds enough float
+// accumulation-order noise to exceed the tests' tight gradient tolerances.
+// LABELED_PARTITION dispatches here on HIP, cg::labeled_partition on CUDA, so the
+// call sites are unchanged. The tile shfl is width-32 (restricted to the tile's
+// own lanes by HIP), so a tiled_partition<32> reduces correctly per 32-lane group
+// on wave64 (gfx90a) exactly as on a 32-lane NVIDIA warp.
+struct LabeledGroup {
+    unsigned long long mask;
+    uint32_t lane;
+    __device__ uint32_t size() const { return __popcll(mask); }
+    __device__ uint32_t thread_rank() const {
+        return __popcll(mask & ((1ull << lane) - 1));
+    }
+    template <class T> __device__ T all_reduce_sum(T val) const {
+        T acc = T(0);
+        unsigned long long m = mask;
+        while (m) {
+            int src = __ffsll((long long)m) - 1;
+            acc += __shfl(val, src, 32);
+            m &= m - 1;
+        }
+        return acc;
+    }
+};
+template <class WarpT, class LabelT>
+inline __device__ LabeledGroup labeled_partition_compat(WarpT &warp, LabelT label) {
+    LabeledGroup g;
+    g.mask = warp.match_any(label);
+    g.lane = warp.thread_rank();
+    return g;
+}
+#define LABELED_PARTITION(warp, label) labeled_partition_compat(warp, label)
+#else
+#define LABELED_PARTITION(warp, label) cg::labeled_partition(warp, label)
+#endif
+
+template <class T, class WarpT> inline __device__ T warpReduceSum(T val, WarpT &warp) {
+#if defined(USE_ROCM)
+    PRAGMA_UNROLL
+    for (uint32_t offset = warp.size() / 2; offset > 0; offset >>= 1) {
+        val += warp.shfl_xor(val, offset);
+    }
+    return val;
+#else
+    return cg::reduce(warp, val, cg::plus<T>());
+#endif
+}
+
+template <class T, class WarpT> inline __device__ T warpReduceMax(T val, WarpT &warp) {
+#if defined(USE_ROCM)
+    PRAGMA_UNROLL
+    for (uint32_t offset = warp.size() / 2; offset > 0; offset >>= 1) {
+        val = max(val, warp.shfl_xor(val, offset));
+    }
+    return val;
+#else
+    return cg::reduce(warp, val, cg::greater<T>());
+#endif
+}
+
+#if defined(USE_ROCM)
+// Route warpReduceSum over a LabeledGroup through the masked same-label reduction
+// (the full-tile butterfly above only works on a power-of-two lane set).
+template <class T> inline __device__ T warpReduceSum(T val, LabeledGroup &g) {
+    return g.all_reduce_sum(val);
+}
+#endif
+
 template <uint32_t DIM, class T, class WarpT>
 inline __device__ void warpSum(T *val, WarpT &warp) {
     PRAGMA_UNROLL
     for (uint32_t i = 0; i < DIM; i++) {
-        val[i] = cg::reduce(warp, val[i], cg::plus<T>());
+        val[i] = warpReduceSum(val[i], warp);
     }
 }
 
 template <class WarpT> inline __device__ void warpSum(float3 &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<float>());
-    val.y = cg::reduce(warp, val.y, cg::plus<float>());
-    val.z = cg::reduce(warp, val.z, cg::plus<float>());
+    val.x = warpReduceSum(val.x, warp);
+    val.y = warpReduceSum(val.y, warp);
+    val.z = warpReduceSum(val.z, warp);
 }
 
 template <class WarpT> inline __device__ void warpSum(float2 &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<float>());
-    val.y = cg::reduce(warp, val.y, cg::plus<float>());
+    val.x = warpReduceSum(val.x, warp);
+    val.y = warpReduceSum(val.y, warp);
 }
 
 template <class WarpT> inline __device__ void warpSum(float &val, WarpT &warp) {
-    val = cg::reduce(warp, val, cg::plus<float>());
+    val = warpReduceSum(val, warp);
 }
 
 template <class WarpT> inline __device__ void warpSum(glm::vec4 &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<float>());
-    val.y = cg::reduce(warp, val.y, cg::plus<float>());
-    val.z = cg::reduce(warp, val.z, cg::plus<float>());
-    val.w = cg::reduce(warp, val.w, cg::plus<float>());
+    val.x = warpReduceSum(val.x, warp);
+    val.y = warpReduceSum(val.y, warp);
+    val.z = warpReduceSum(val.z, warp);
+    val.w = warpReduceSum(val.w, warp);
 }
 
 template <class WarpT> inline __device__ void warpSum(glm::vec3 &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<float>());
-    val.y = cg::reduce(warp, val.y, cg::plus<float>());
-    val.z = cg::reduce(warp, val.z, cg::plus<float>());
+    val.x = warpReduceSum(val.x, warp);
+    val.y = warpReduceSum(val.y, warp);
+    val.z = warpReduceSum(val.z, warp);
 }
 
 template <class WarpT> inline __device__ void warpSum(glm::vec2 &val, WarpT &warp) {
-    val.x = cg::reduce(warp, val.x, cg::plus<float>());
-    val.y = cg::reduce(warp, val.y, cg::plus<float>());
+    val.x = warpReduceSum(val.x, warp);
+    val.y = warpReduceSum(val.y, warp);
 }
 
 template <class WarpT> inline __device__ void warpSum(glm::mat4 &val, WarpT &warp) {
@@ -74,7 +164,7 @@ template <class WarpT> inline __device__ void warpSum(glm::mat2 &val, WarpT &war
 }
 
 template <class WarpT> inline __device__ void warpMax(float &val, WarpT &warp) {
-    val = cg::reduce(warp, val, cg::greater<float>());
+    val = warpReduceMax(val, warp);
 }
 
 inline __device__ void compute_pix_velocity(

--- a/gsplat/cuda/csrc/projection.cu
+++ b/gsplat/cuda/csrc/projection.cu
@@ -4,12 +4,20 @@
 #include "third_party/glm/glm/gtc/type_ptr.hpp"
 #include "utils.cuh"
 #include <cooperative_groups.h>
+#if !defined(USE_ROCM)
 #include <cooperative_groups/reduce.h>
+#endif
 #include <cub/cub.cuh>
 #include <cuda.h>
 #include <cuda_runtime.h>
 
 namespace cg = cooperative_groups;
+
+#if defined(USE_ROCM)
+// hipify rewrites <cub/cub.cuh> -> <hipcub/hipcub.hpp> but leaves the cub::
+// namespace unrenamed, so cub::BlockReduce / cub::BlockScan would be undeclared.
+namespace cub = hipcub;
+#endif
 
 /****************************************************************************
  * Quat-Scale to Covariance and Precision
@@ -482,7 +490,7 @@ world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
     // #if __CUDA_ARCH__ >= 700
     // write out results with warp-level reduction
     auto warp = cg::tiled_partition<32>(cg::this_thread_block());
-    auto warp_group_g = cg::labeled_partition(warp, gid);
+    auto warp_group_g = LABELED_PARTITION(warp, gid);
     if (v_means != nullptr) {
         warpSum(v_mean, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
@@ -507,7 +515,7 @@ world_to_cam_bwd_kernel(const uint32_t C, const uint32_t N,
         }
     }
     if (v_viewmats != nullptr) {
-        auto warp_group_c = cg::labeled_partition(warp, cid);
+        auto warp_group_c = LABELED_PARTITION(warp, cid);
         warpSum(v_R, warp_group_c);
         warpSum(v_t, warp_group_c);
         if (warp_group_c.thread_rank() == 0) {
@@ -902,7 +910,7 @@ __global__ void fully_fused_projection_bwd_kernel(
     // #if __CUDA_ARCH__ >= 700
     // write out results with warp-level reduction
     auto warp = cg::tiled_partition<32>(cg::this_thread_block());
-    auto warp_group_g = cg::labeled_partition(warp, gid);
+    auto warp_group_g = LABELED_PARTITION(warp, gid);
     if (v_means != nullptr) {
         warpSum(v_mean, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
@@ -946,7 +954,7 @@ __global__ void fully_fused_projection_bwd_kernel(
         }
     }
     if (v_viewmats != nullptr) {
-        auto warp_group_c = cg::labeled_partition(warp, cid);
+        auto warp_group_c = LABELED_PARTITION(warp, cid);
         warpSum(v_R, warp_group_c);
         warpSum(v_t, warp_group_c);
         if (warp_group_c.thread_rank() == 0) {
@@ -1652,7 +1660,7 @@ __global__ void fully_fused_projection_packed_bwd_kernel(
         // write out results with dense layout
         // #if __CUDA_ARCH__ >= 700
         // write out results with warp-level reduction
-        auto warp_group_g = cg::labeled_partition(warp, gid);
+        auto warp_group_g = LABELED_PARTITION(warp, gid);
         if (v_means != nullptr) {
             warpSum(v_mean, warp_group_g);
             if (warp_group_g.thread_rank() == 0) {
@@ -1698,7 +1706,7 @@ __global__ void fully_fused_projection_packed_bwd_kernel(
     }
     // v_viewmats is always in dense layout
     if (v_viewmats != nullptr) {
-        auto warp_group_c = cg::labeled_partition(warp, cid);
+        auto warp_group_c = LABELED_PARTITION(warp, cid);
         warpSum(v_R, warp_group_c);
         warpSum(v_t, warp_group_c);
         if (warp_group_c.thread_rank() == 0) {
@@ -2567,7 +2575,7 @@ __global__ void fully_fused_lidar_projection_bwd_kernel(
     // #if __CUDA_ARCH__ >= 700
     // write out results with warp-level reduction
     auto warp = cg::tiled_partition<32>(cg::this_thread_block());
-    auto warp_group_g = cg::labeled_partition(warp, gid);
+    auto warp_group_g = LABELED_PARTITION(warp, gid);
     if (v_means != nullptr) {
         warpSum(v_mean, warp_group_g);
         if (warp_group_g.thread_rank() == 0) {
@@ -2611,7 +2619,7 @@ __global__ void fully_fused_lidar_projection_bwd_kernel(
         }
     }
     if (v_viewmats != nullptr) {
-        auto warp_group_c = cg::labeled_partition(warp, cid);
+        auto warp_group_c = LABELED_PARTITION(warp, cid);
         warpSum(v_R, warp_group_c);
         warpSum(v_t, warp_group_c);
         if (warp_group_c.thread_rank() == 0) {

--- a/gsplat/cuda/csrc/rasterization.cu
+++ b/gsplat/cuda/csrc/rasterization.cu
@@ -8,6 +8,14 @@
 
 namespace cg = cooperative_groups;
 
+#if defined(USE_ROCM)
+// hipify rewrites <cub/cub.cuh> -> <hipcub/hipcub.hpp> but leaves the cub::
+// namespace unrenamed, so cub::DeviceRadixSort / cub::DoubleBuffer would be
+// undeclared. The SortPairs begin_bit is 0 (full-width sort), so the cudaKDTree
+// nonzero-begin_bit hipCUB bug does not apply.
+namespace cub = hipcub;
+#endif
+
 /****************************************************************************
  * Gaussian Tile Intersection
  ****************************************************************************/
@@ -1064,7 +1072,7 @@ std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_tensor(
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
     const uint32_t shared_mem =
         tile_size * tile_size * (sizeof(int32_t) + sizeof(float3) + sizeof(float3) + sizeof(float2));
-    if (cudaFuncSetAttribute(rasterize_to_indices_in_range_kernel,
+    if (cudaFuncSetAttribute((const void *)rasterize_to_indices_in_range_kernel,
                              cudaFuncAttributeMaxDynamicSharedMemorySize,
                              shared_mem) != cudaSuccess) {
         AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1331,7 +1339,7 @@ std::tuple<torch::Tensor, torch::Tensor> rasterize_to_indices_in_range_lidar_ten
     at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
     const uint32_t shared_mem =
         tile_width * tile_height * (sizeof(int32_t) + sizeof(float3) + sizeof(float3) + sizeof(float3));
-    if (cudaFuncSetAttribute(rasterize_to_indices_in_range_lidar_kernel,
+    if (cudaFuncSetAttribute((const void *)rasterize_to_indices_in_range_lidar_kernel,
                              cudaFuncAttributeMaxDynamicSharedMemorySize,
                              shared_mem) != cudaSuccess) {
         AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1636,7 +1644,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
     // moving the channel padding from python to C side.
     switch (channels) {
     case 1:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<1>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<1>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1660,7 +1668,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 2:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<2>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<2>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1684,7 +1692,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 3:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<3>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<3>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1708,7 +1716,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 4:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<4>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<4>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1732,7 +1740,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 5:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<5>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<5>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1756,7 +1764,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 8:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<8>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<8>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1780,7 +1788,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 9:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<9>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<9>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1804,7 +1812,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 16:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<16>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<16>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1828,7 +1836,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 17:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<17>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<17>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1852,7 +1860,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 32:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<32>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<32>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1876,7 +1884,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 33:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<33>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<33>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1900,7 +1908,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 64:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<64>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<64>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1924,7 +1932,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 65:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<65>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<65>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1948,7 +1956,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 128:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<128>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<128>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1972,7 +1980,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 129:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<129>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<129>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -1996,7 +2004,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 256:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<256>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<256>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2020,7 +2028,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 257:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<257>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<257>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2044,7 +2052,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 512:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<512>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<512>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2068,7 +2076,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor> rasterize
             last_ids.data_ptr<int32_t>());
         break;
     case 513:
-        if (cudaFuncSetAttribute(rasterize_to_pixels_fwd_kernel<513>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_fwd_kernel<513>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2372,7 +2380,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
     // moving the channel padding from python to C side.
     switch (channels) {
     case 1:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<1>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<1>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2400,7 +2408,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 2:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<2>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<2>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2428,7 +2436,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 3:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<3>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<3>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2456,7 +2464,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 4:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<4>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<4>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2484,7 +2492,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 5:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<5>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<5>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2512,7 +2520,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 8:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<8>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<8>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2540,7 +2548,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 9:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<9>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<9>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2568,7 +2576,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 16:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<16>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<16>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2596,7 +2604,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 17:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<17>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<17>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2624,7 +2632,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 32:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<32>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<32>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2652,7 +2660,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 33:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<33>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<33>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2680,7 +2688,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 64:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<64>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<64>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2708,7 +2716,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 65:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<65>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<65>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2736,7 +2744,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 128:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<128>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<128>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2764,7 +2772,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 129:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<129>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<129>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2792,7 +2800,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 256:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<256>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<256>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2820,7 +2828,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 257:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<257>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<257>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2848,7 +2856,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 512:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<512>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<512>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -2876,7 +2884,7 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
             last_ids.data_ptr<int32_t>(), median_depths.data_ptr<float>());
         break;
     case 513:
-        if (cudaFuncSetAttribute(rasterize_to_points_fwd_kernel<513>,
+        if (cudaFuncSetAttribute((const void *)rasterize_to_points_fwd_kernel<513>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize,
                                  shared_mem) != cudaSuccess) {
             AT_ERROR("Failed to set maximum shared memory size (requested ", shared_mem,
@@ -3027,7 +3035,7 @@ __global__ void rasterize_to_pixels_bwd_kernel(
     // each thread loads one gaussian at a time before rasterizing
     const uint32_t tr = block.thread_rank();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
-    const int32_t warp_bin_final = cg::reduce(warp, bin_final, cg::greater<int>());
+    const int32_t warp_bin_final = warpReduceMax(bin_final, warp);
     for (uint32_t b = 0; b < num_batches; ++b) {
         // resync all threads before writing next batch of shared mem
         block.sync();
@@ -3263,7 +3271,7 @@ rasterize_to_pixels_bwd_tensor(
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
         switch (COLOR_DIM) {
         case 1:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<1>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<1>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3292,7 +3300,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 2:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<2>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<2>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3321,7 +3329,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 3:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<3>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<3>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3350,7 +3358,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 4:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<4>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<4>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3379,7 +3387,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 5:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<5>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<5>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3408,7 +3416,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 8:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<8>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<8>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3437,7 +3445,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 9:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<9>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<9>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3466,7 +3474,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 16:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<16>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<16>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3495,7 +3503,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 17:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<17>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<17>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3524,7 +3532,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 32:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<32>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<32>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3553,7 +3561,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 33:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<33>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<33>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3582,7 +3590,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 64:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<64>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<64>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3611,7 +3619,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 65:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<65>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<65>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3640,7 +3648,7 @@ rasterize_to_pixels_bwd_tensor(
                 v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 128:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<128>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<128>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3670,7 +3678,7 @@ rasterize_to_pixels_bwd_tensor(
                     v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 129:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<129>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<129>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3700,7 +3708,7 @@ rasterize_to_pixels_bwd_tensor(
                     v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 256:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<256>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<256>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3730,7 +3738,7 @@ rasterize_to_pixels_bwd_tensor(
                     v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 257:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<257>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<257>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3760,7 +3768,7 @@ rasterize_to_pixels_bwd_tensor(
                     v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 512:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<512>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<512>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3790,7 +3798,7 @@ rasterize_to_pixels_bwd_tensor(
                     v_opacities.data_ptr<float>(), (float2 *)v_pix_vels.data_ptr<float>());
             break;
         case 513:
-            if (cudaFuncSetAttribute(rasterize_to_pixels_bwd_kernel<513>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_pixels_bwd_kernel<513>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -3949,7 +3957,7 @@ __global__ void rasterize_to_points_bwd_kernel(
     // each thread loads one gaussian at a time before rasterizing
     const uint32_t tr = block.thread_rank();
     cg::thread_block_tile<32> warp = cg::tiled_partition<32>(block);
-    const int32_t warp_bin_final = cg::reduce(warp, bin_final, cg::greater<int>());
+    const int32_t warp_bin_final = warpReduceMax(bin_final, warp);
 
     for (uint32_t b = 0; b < num_batches; ++b) {
         // resync all threads before writing next batch of shared mem
@@ -4237,7 +4245,7 @@ rasterize_to_points_bwd_tensor(
         at::cuda::CUDAStream stream = at::cuda::getCurrentCUDAStream();
         switch (COLOR_DIM) {
         case 1:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<1>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<1>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4274,7 +4282,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 2:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<2>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<2>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4311,7 +4319,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 3:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<3>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<3>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4348,7 +4356,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 4:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<4>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<4>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4385,7 +4393,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 5:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<5>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<5>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4422,7 +4430,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 8:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<8>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<8>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4459,7 +4467,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 9:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<9>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<9>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4496,7 +4504,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 16:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<16>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<16>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4533,7 +4541,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 17:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<17>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<17>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4570,7 +4578,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 32:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<32>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<32>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4607,7 +4615,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 33:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<33>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<33>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4644,7 +4652,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 64:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<64>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<64>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4681,7 +4689,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 65:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<65>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<65>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4718,7 +4726,7 @@ rasterize_to_points_bwd_tensor(
                 (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 128:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<128>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<128>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4756,7 +4764,7 @@ rasterize_to_points_bwd_tensor(
                     (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 129:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<129>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<129>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4794,7 +4802,7 @@ rasterize_to_points_bwd_tensor(
                     (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 256:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<256>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<256>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4832,7 +4840,7 @@ rasterize_to_points_bwd_tensor(
                     (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 257:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<257>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<257>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4870,7 +4878,7 @@ rasterize_to_points_bwd_tensor(
                     (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 512:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<512>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<512>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",
@@ -4908,7 +4916,7 @@ rasterize_to_points_bwd_tensor(
                     (float2 *)v_depth_compensations.data_ptr<float>());
             break;
         case 513:
-            if (cudaFuncSetAttribute(rasterize_to_points_bwd_kernel<513>,
+            if (cudaFuncSetAttribute((const void *)rasterize_to_points_bwd_kernel<513>,
                                      cudaFuncAttributeMaxDynamicSharedMemorySize,
                                      shared_mem) != cudaSuccess) {
                 AT_ERROR("Failed to set maximum shared memory size (requested ",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import glob
 import os
 import os.path as osp
 import platform
+import shutil
 import sys
 
 from setuptools import find_packages, setup
@@ -16,10 +17,56 @@ WITH_SYMBOLS = os.getenv("WITH_SYMBOLS", "0") == "1"
 LINE_INFO = os.getenv("LINE_INFO", "0") == "1"
 
 
+def _patch_hipify_ignore_glm():
+    """Keep the bundled third_party/glm out of torch's hipify on ROCm.
+
+    torch's hipify (via CUDAExtension) walks every .hpp under the build dir and
+    the extension include dirs into its file set, then content-rewrites any GLM
+    header a source pulls in -- which drops GLM's .inl files (hipify only copies
+    .hpp/.h) and mangles GLM's __CUDACC__/__HIP__ compiler detection, breaking
+    the build. GLM 1.0.x already detects __HIP__ and compiles verbatim under the
+    -x hip pass, so the fix is simply to leave it untouched: add the glm dir to
+    hipify's ``ignores`` and drop it from ``header_include_dirs``. The source
+    keeps including <glm/...> via -I, resolved against the pristine bundled tree.
+    """
+    import torch
+
+    if not torch.version.hip:
+        return
+    from torch.utils.hipify import hipify_python
+
+    glm_dir = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "gsplat", "cuda", "csrc", "third_party", "glm",
+    )
+    glm_patterns = [os.path.join(glm_dir, "*"), glm_dir + "*"]
+    orig_hipify = hipify_python.hipify
+
+    def hipify_no_glm(*args, **kwargs):
+        kwargs["ignores"] = list(kwargs.get("ignores", ())) + glm_patterns
+        kwargs["header_include_dirs"] = [
+            d for d in kwargs.get("header_include_dirs", [])
+            if os.path.abspath(d) != os.path.abspath(glm_dir)
+        ]
+        return orig_hipify(*args, **kwargs)
+
+    hipify_python.hipify = hipify_no_glm
+
+
+if BUILD_CUDA:
+    _patch_hipify_ignore_glm()
+
+
 def get_ext():
+    import torch
     from torch.utils.cpp_extension import BuildExtension
 
-    return BuildExtension.with_options(no_python_abi_suffix=True, use_ninja=False)
+    # On Windows+ROCm, the non-ninja distutils builder cannot handle .hip files
+    # (torch hipify renames .cu -> .hip) and does not forward __HIP_PLATFORM_AMD__
+    # to MSVC for .cpp files; ninja handles both. Force ninja for that case only,
+    # leaving the CUDA build's default (use_ninja=False) untouched.
+    use_ninja = sys.platform == "win32" and bool(torch.version.hip)
+    return BuildExtension.with_options(no_python_abi_suffix=True, use_ninja=use_ninja)
 
 
 def get_extensions():
@@ -28,10 +75,30 @@ def get_extensions():
     from torch.utils.cpp_extension import CUDAExtension
 
     extensions_dir = osp.join("gsplat", "cuda", "csrc")
+    # On Windows with ninja, the build runs from a temp directory so relative
+    # include paths don't resolve. Use absolute path for the extension dir.
+    abs_extensions_dir = osp.abspath(extensions_dir)
     sources = glob.glob(osp.join(extensions_dir, "*.cu")) + glob.glob(
         osp.join(extensions_dir, "*.cpp")
     )
-    sources = [path for path in sources if "hip" not in path]
+    sources = [path for path in sources if "hip" not in path and "_winhip" not in path]
+
+    if sys.platform == "win32" and torch.version.hip:
+        # On Windows+ROCm, compiling .cpp files with MSVC cl.exe (the torch default
+        # for .cpp) fails to link: inherited constructors in c10-dllexport classes
+        # (e.g. c10::ValueError) are instantiated in the TU but not exported from
+        # c10.dll, causing LNK2001. amdclang (hipcc), used for .cu/.hip, handles
+        # this correctly. Route each .cpp through hipcc by creating a same-dir
+        # _winhip.cu shim (a copy) so relative #includes resolve.
+        shim_sources = []
+        for s in sources:
+            if s.endswith(".cpp"):
+                shim = s[:-4] + "_winhip.cu"
+                shutil.copyfile(s, shim)
+                shim_sources.append(shim)
+            else:
+                shim_sources.append(s)
+        sources = shim_sources
 
     undef_macros = []
     define_macros = []
@@ -42,7 +109,7 @@ def get_extensions():
     extra_compile_args = {"cxx": ["-O3"]}
     if not os.name == "nt":  # Not on Windows:
         extra_compile_args["cxx"] += ["-Wno-sign-compare"]
-    extra_link_args = [] if WITH_SYMBOLS else ["-s"]
+    extra_link_args = [] if (WITH_SYMBOLS or sys.platform == "win32") else ["-s"]
 
     info = parallel_info()
     if (
@@ -65,7 +132,7 @@ def get_extensions():
 
     nvcc_flags = os.getenv("NVCC_FLAGS", "")
     nvcc_flags = [] if nvcc_flags == "" else nvcc_flags.split(" ")
-    nvcc_flags += ["-O3", "--use_fast_math"]
+    nvcc_flags += ["-O3"]
     if LINE_INFO:
         nvcc_flags += ["-lineinfo"]
     if torch.version.hip:
@@ -73,8 +140,19 @@ def get_extensions():
         # Define here to support older PyTorch versions as well:
         define_macros += [("USE_ROCM", None)]
         undef_macros += ["__HIP_NO_HALF_CONVERSIONS__"]
+        # GLM's operator[] bounds checks expand to assert() -> __assert_fail, a
+        # __host__ function referenced from GLM's __host__ __device__ accessors.
+        # nvcc tolerates this (it supplies a device assert); ROCm clang rejects it.
+        # NDEBUG makes the debug-only bounds asserts no-ops (the indices here are
+        # compile-time constants, always in range) -- the standard release define.
+        nvcc_flags += ["-DNDEBUG"]
+        # ROCm clang's fast-math is more aggressive than CUDA's --use_fast_math
+        # and perturbs ill-conditioned projection/covariance gradients past the
+        # upstream test tolerances, so keep it OFF by default (opt-in FAST_MATH=1).
+        if os.getenv("FAST_MATH", "0") == "1":
+            nvcc_flags += ["-ffast-math"]
     else:
-        nvcc_flags += ["--expt-relaxed-constexpr"]
+        nvcc_flags += ["--use_fast_math", "--expt-relaxed-constexpr"]
     extra_compile_args["nvcc"] = nvcc_flags
     if sys.platform == "win32":
         extra_compile_args["nvcc"] += ["-DWIN32_LEAN_AND_MEAN"]
@@ -82,7 +160,7 @@ def get_extensions():
     extension = CUDAExtension(
         f"gsplat.csrc",
         sources,
-        include_dirs=[extensions_dir],
+        include_dirs=[abs_extensions_dir],
         define_macros=define_macros,
         undef_macros=undef_macros,
         extra_compile_args=extra_compile_args,


### PR DESCRIPTION
This adds AMD GPU support to SplatAD's camera and lidar rendering extension on ROCm. The `gsplat.csrc` extension compiles against a ROCm build of PyTorch, and both rendering paths -- the camera 3DGS rasterizer and the SplatAD lidar spherical rasterization -- run against the project's own pure-PyTorch reference (`gsplat/cuda/_torch_impl.py`).

splatad is gsplat v1.0.0 plus a lidar path; this applies the same ROCm approach to the flat csrc layout and extends it over the lidar kernels. torch hipifies the .cu/.cuh at build time, so the sources keep their CUDA spellings; every fix is behind a `USE_ROCM` (or `__HIP__`) guard. We have made every effort to leave the CUDA build unchanged -- the CUDA path does not compile the ROCm branches. The cross-lane reductions use cooperative-groups `tiled_partition<32>`, whose width-32 shuffles stay inside the 32-lane tile, so the same source is correct on wave64 (CDNA) and wave32 (RDNA) without per-arch code.

The main changes:
- `setup.py`: leave the bundled `third_party/glm` untouched by hipify (it compiles verbatim under `-x hip`), add `-DNDEBUG` so GLM's bounds-assert does not emit a host `__assert_fail` in device code, and keep clang fast-math off by default (it perturbs ill-conditioned covariance gradients past the upstream test tolerances).
- `helpers.cuh` / `bindings.h`: include the HIP runtime before GLM so `glm::make_vec`/`make_mat` bind HIP's device memcpy overload.
- `helpers.cuh`: replace `cg::reduce` (absent in HIP) with a width-32 `shfl_xor` butterfly all-reduce, and rebuild `cg::labeled_partition` (also absent) from `warp.match_any` so each distinct gradient label issues exactly one `atomicAdd` -- matching CUDA's atomic granularity, which a per-lane fan-out would not (it changes the float accumulation order enough to flap the projection gradient tests).
- `rasterization.cu` / `projection.cu`: alias `namespace cub = hipcub`, and cast every `cudaFuncSetAttribute` kernel argument to `const void*` (HIP's `hipFuncSetAttribute` has only that overload; CUDA accepts it too).
- A few Windows-only build adjustments (MSVC host compiler), guarded by `sys.platform=="win32"`/`__HIP__`.

Validated against the project's pure-PyTorch reference on:
- gfx90a (MI250X, wave64, Linux, ROCm 7.2.1)
- gfx1100 (Radeon Pro W7800, RDNA3, wave32, Linux, ROCm 7.2.1)
- gfx1201 (RX 9070 XT, RDNA4, wave32, Windows, ROCm via TheRock)

Camera math, camera rasterization (RGB / RGB+D / D), lidar math, and end-to-end lidar rasterization all pass. The lidar `rasterize_to_points` fwd+bwd (whose upstream reference imports nerfacc, unavailable on ROCm) was validated independently: bit-deterministic forward, finite backward grads with a finite-difference slope of 1.0, and an 80-step Adam fit that drives the loss down ~99%.

A handful of gradient elements at near-degenerate gaussians flap run-to-run at the tightest tolerances and pass in isolation -- the expected float-atomicAdd accumulation-order noise (nondeterministic on every GPU including CUDA), not a wave-size defect. Upstream tolerances are left unchanged.

This work was authored with the assistance of Claude (Anthropic), an AI assistant, as part of an effort to port popular CUDA projects to ROCm/HIP.
